### PR TITLE
SAML(User): Don't get when use old Fortigate release (< 6.2.0)

### DIFF
--- a/Src/Private/Get-AbrFgtUser.ps1
+++ b/Src/Private/Get-AbrFgtUser.ps1
@@ -34,7 +34,9 @@ function Get-AbrFgtUser {
             $Groups = Get-FGTUserGroup
             $LDAPS = Get-FGTUserLDAP
             $RADIUS = Get-FGTUserRADIUS
-            $SAML = Get-FGTUserSAML
+            if ($DefaultFGTConnection.version -ge "6.2.0") {
+                $SAML = Get-FGTUserSAML
+            }
 
             if ($InfoLevel.User -ge 1) {
                 Section -Style Heading3 'Summary' {


### PR DESCRIPTION
Before 6.2.0, SAML is not available and Get-FGTUSerSAML generate Throw

