### PR TITLE
FortiCare: don't need to ToLower() FortiCare Account

### DIFF
--- a/Src/Private/Get-AbrFgtFortiCare.ps1
+++ b/Src/Private/Get-AbrFgtFortiCare.ps1
@@ -153,7 +153,7 @@ function Get-AbrFgtForticare {
                     "Model"   = $Model
                     "Serial"  = $Serial
                     "Status"  = $Forticare.status
-                    "Account" = $Forticare.account.ToLower()
+                    "Account" = $Forticare.account
                     "Company" = $Forticare.company
                 }
 


### PR DESCRIPTION
it will be fix You cannot call a method on a null-valued expression (#105)
