### PR TITLE
Fix(Forticare): Avoid warning when don't Support

### DIFF
--- a/Src/Private/Get-AbrFgtFortiCare.ps1
+++ b/Src/Private/Get-AbrFgtFortiCare.ps1
@@ -204,14 +204,14 @@ function Get-AbrFgtForticare {
 
                 Paragraph "The following section details support settings configured on FortiGate."
                 BlankLine
-                $ExpiresHW = (($Forticare | Select-Object -ExpandProperty support).hardware).expires
+                $ExpiresHW = $Forticare.support.hardware.expires
                 $SupportHW = [pscustomobject]@{
                     "Type"            = "Hardware"
                     "Level"           = $Forticare.support.hardware.support_level
                     "Status"          = $Forticare.support.hardware.status
                     "Expiration Date" = (Get-Date 01.01.1970) + ([System.TimeSpan]::fromseconds($ExpiresHW)) | Get-Date -Format dd/MM/yyyy
                 }
-                $ExpiresEn = (($Forticare | Select-Object -ExpandProperty support).enhanced).expires
+                $ExpiresEn = $Forticare.support.enhanced.expires
                 $SupportEn = [pscustomobject]@{
                     "Type"            = "Enhanced"
                     "Level"           = $Forticare.support.enhanced.support_level


### PR DESCRIPTION
Select-Object : Property 'support' cannot be found.

second fix of #105 